### PR TITLE
Fix syntax error

### DIFF
--- a/posts/swift-for-cxx-practitioners-extensions/index.html
+++ b/posts/swift-for-cxx-practitioners-extensions/index.html
@@ -47,7 +47,7 @@
 }
 </code></pre><p>In Swift, most of the types one thinks of as built-in---integers, floating point numbers, Booleans, optionals, arrays, etc.---are actually structs or enums provided by the standard library. Therefore, you can extend them with new functionality. For example, maybe we want to add a property that determines whether a given integer is prime. We can do so by extending <code>Int</code>:</p><pre><code><span class="keyword">extension</span> <span class="type">Int</span> {
   <span class="keyword">var</span> isPrime: <span class="type">Bool</span> {
-    <span class="keyword">switch</span> swift {
+    <span class="keyword">switch</span> self {
       <span class="keyword">case</span> <span class="number">0</span>: <span class="keyword">return false
       case</span> <span class="number">1</span>: <span class="keyword">return true
       default</span>: <span class="keyword">break</span>


### PR DESCRIPTION
My only change is in line 50: switch over `self` not `swift` in the extension on Int. (I don't know why line 166 changed too)

I realize the source of truth for this post is probably a markdown file somewhere, this PR is just show where the typo is. Free free to close.

I'm also surprised to see 1 considered prime, but [I guess there's precedent](https://en.wikipedia.org/wiki/Prime_number#Primality_of_one).

Anyway, I love these posts. Thank you so much for taking the time to write this up. I'm getting a lot out of them and I'm not even an experienced C++ person.